### PR TITLE
SignalOutput

### DIFF
--- a/README
+++ b/README
@@ -117,8 +117,26 @@ file.path=c:\
 cons.level=trace
 cons.outputType=console
 cons.logMask=time:%t owner:%o level:%l function:%f line:%n message:%m
--------------------------------------------------------------------------------
 
+# third level will log to a QT signal called logMessage(QString)
+sigs.level=trace
+sigs.outputType=SIGNAL
+
+-------------------------------------------------------------------------------
+	// Assuming a QPlainTexrEdit has called plainTextEdit been created in the 
+	// Qt Ui form, a connection needs to be made..
+    QObject::connect(QLogger::getInstance(), &QLogger::logMessage,
+                     ui->plainTextEdit, &QPlainTextEdit::appendPlainText);
+
+	// then the log messages should be made as normal.
+    QLOG_ERROR("error message", "sigs");
+    QLOG_WARN("warn message", "sigs");
+    QLOG_DEBUG("debug message", "sigs");
+    QLOG_INFO("info message", "sigs");
+    QLOG_TRACE("trace message", "sigs");
+    
+-------------------------------------------------------------------------------
+    
 This small readme covered almost everything QLogger is capable to do, there are some
 other configurations and details, but they are pretty straight forward to understand
 by reading the code.

--- a/configfilehandler.h
+++ b/configfilehandler.h
@@ -78,7 +78,7 @@ class ConfigFileHandler {
 private:
     inline static void recursiveFolderSearch(QDir &dir, bool &found) {
         QDir path(dir.absolutePath());
-        QStringList list = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+        QStringList list = dir.entryList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
         const int size = list.size();
 
         for (int i = 0; i < size; ++i) {

--- a/configfilehandler.h
+++ b/configfilehandler.h
@@ -83,15 +83,12 @@ private:
 
         for (int i = 0; i < size; ++i) {
             QString currentPath = list.at(i);
+            QFileInfo info = QFileInfo(currentPath);
 
             if (found) {
                 return;
 
-            } else if (QFile::exists(CH_CONFIG_FILE_NAME)) {
-                found = true;
-                return;
-
-            } else {
+            } else if (info.isDir()) {
                 found = false;
                 dir.cd(currentPath);
                 recursiveFolderSearch(dir, found);
@@ -99,7 +96,15 @@ private:
                 if (!found) {
                     dir.cdUp();
                 }
+
+            } else {
+                if (QFile::exists(CH_CONFIG_FILE_NAME)) {
+                    found = true;
+                    return;
+                }
+
             }
+
         }
     }
 

--- a/configfilehandler.h
+++ b/configfilehandler.h
@@ -1,53 +1,60 @@
 /*
- * QLogger - A tiny Qt logging framework.
- *
- * MIT License
- * Copyright (c) 2013 sandro fadiga
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies
- * or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
- * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    QLogger - A tiny Qt logging framework.
+
+    MIT License
+    Copyright (c) 2013 sandro fadiga
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 */
 
 #ifndef CONFIGFILEHANDLER_H
 #define CONFIGFILEHANDLER_H
 
-#include <QFileInfo>
 #include <QDir>
+#include <QFileInfo>
 #include <QMultiHash>
 #include "configuration.h"
 
-namespace qlogger
-{
+namespace qlogger {
 
 //! This class is responsible to search on program path for a configuration file
-//! Then read and parse this configuration file to generate valid configurations from it
+//! Then read and parse this configuration file to generate valid configurations
+//! from it
 //!
 //! The file must be a plain text file with the name qlogger.cfg
 //! The following texts are valid on config file.
 //!
 //! # comment line example
 //! owner.level = { FATAL, ERROR, WARN, INFO, DEBUG, TRACE }
-//! owner.outputType = { CONSOLE, TEXT, XML }
+//! owner.outputType = { CONSOLE, TEXT, XML, SIGNAL }
 //! owner.logMask =
-//!    { for console and text can use the symbols %t %o %l %m , if does not contain %t %l and %m will use the default }
+//!    { for console and text can use the symbols %t %o %l %m , if does not
+//!    contain %t %l and %m will use the default }
 //! owner.maxFileSize = {in kb just a number 100, 1000... only for TEXT and XML}
-//! owner.path = { a valid absolut path on the system, if invalid path is given then will default to app path }
-//! owner.timestampFormat =
-//!    { the Qt format for datetime used to format the %t part of console and text and date_time tag of XML, it defaults to platform short format }
-//! owner.fileName = { file name mask, must contain all %1 %2 %3 params, example: log_%1_%2_%3.txt
-//! owner.fileNameTimeStamp = { the timestamp that will be written in param %3 of the file name mask, must follow QTimeDate string format.
+//! owner.path = { a valid absolut path on the system, if invalid path is given
+//! then will default to app path } owner.timestampFormat =
+//!    { the Qt format for datetime used to format the %t part of console and
+//!    text and date_time tag of XML, it defaults to platform short format }
+//! owner.fileName = { file name mask, must contain all %1 %2 %3 params,
+//! example: log_%1_%2_%3.txt owner.fileNameTimeStamp = { the timestamp that
+//! will be written in param %3 of the file name mask, must follow QTimeDate
+//! string format.
 
 static const QString CH_LEVEL = "level";
 
@@ -67,74 +74,71 @@ static const QString CH_FILE_NAME_TIMESTAMP = "fileNameTimeStamp";
 
 static const QString CH_CONFIG_FILE_NAME = "qlogger.cfg";
 
-class ConfigFileHandler
-{
-
+class ConfigFileHandler {
 private:
-
-    inline static void recursiveFolderSearch(QDir& dir, bool &found)
-    {
+    inline static void recursiveFolderSearch(QDir &dir, bool &found) {
         QDir path(dir.absolutePath());
         QStringList list = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
         const int size = list.size();
-        for(int i = 0; i < size ; ++i)
-        {
+
+        for (int i = 0; i < size; ++i) {
             QString currentPath = list.at(i);
-            if(found)
-            {
+
+            if (found) {
                 return;
-            }
-            else if(QFile::exists(CH_CONFIG_FILE_NAME))
-            {
+
+            } else if (QFile::exists(CH_CONFIG_FILE_NAME)) {
                 found = true;
                 return;
-            }
-            else
-            {
+
+            } else {
                 found = false;
                 dir.cd(currentPath);
                 recursiveFolderSearch(dir, found);
-                if(!found)
+
+                if (!found) {
                     dir.cdUp();
+                }
             }
         }
     }
 
 protected:
-
-    inline static bool searchForConfigFile()
-    {
-		QDir dir(QDir::currentPath());
-        //search on the folder tree
+    inline static bool searchForConfigFile() {
+        QDir dir(QDir::currentPath());
+        // search on the folder tree
         bool found = false;
         recursiveFolderSearch(dir, found);
         return found;
     }
 
-    inline static bool createConfiguration(QMultiHash<QString, QString> &ownerConfigLines,
-                                           QList<Configuration*> &configs)//QMultiHash<QString, Configuration*> &loggers)
-    {
+    inline static bool createConfiguration(
+        QMultiHash<QString, QString> &ownerConfigLines,
+        QList<Configuration *>
+        &configs) { // QMultiHash<QString, Configuration*> &loggers)
         QList<QString> configTextList = ownerConfigLines.keys();
         QString currentConfig = QString();
-        bool localTest = false; // the loggers reference could already been filled from somewhere else
+        bool localTest = false;  // the loggers reference could already been filled
+        // from somewhere else
         const int size = configTextList.size();
-        for(int i = 0 ; i < size ; i++)
-        {
+
+        for (int i = 0; i < size; i++) {
             QString configText = configTextList.at(i);
-            if(currentConfig != configText)
-            {
+
+            if (currentConfig != configText) {
                 QStringList values = ownerConfigLines.values(configText);
-                //loggers.insert(config, parseAllLinesOfConfig(config, values));
-				configs.append(parseAllLinesOfConfig(configText, values));
+                // loggers.insert(config, parseAllLinesOfConfig(config, values));
+                configs.append(parseAllLinesOfConfig(configText, values));
                 currentConfig = configText;
                 localTest = true;
             }
         }
-	    return localTest;
+
+        return localTest;
     }
 
-    inline static Configuration* parseAllLinesOfConfig(QString owner, QStringList lines)
-    {
+    inline static Configuration *parseAllLinesOfConfig(QString owner,
+            QStringList lines) {
         // parsing a structure like ( key=value ) * N
         Configuration::Level level = Configuration::q1ERROR;
         Configuration::OutputType outputType = Configuration::CONSOLE;
@@ -144,101 +148,100 @@ protected:
         QString timestampFormat = QString();
         QString fileName = QString();
         QString fileNameTimestamp = QString();
-		int size = lines.size();
-		for (int i = 0 ; i < size ; i++)//(QString line , lines)
-        {
-			QString line = lines.at(i);
+        int size = lines.size();
+
+        for (int i = 0; i < size; i++) { //(QString line , lines)
+            QString line = lines.at(i);
             QStringList configList = line.trimmed().split("=");
-            QString key = configList.isEmpty() ? QString() : configList.at(0); // left hand
-            QString paramValue = configList.size() < 1 ? QString() : configList.at(1); //right hand
-          	 if(key == CH_LEVEL)
-            {
+            QString key =
+                configList.isEmpty() ? QString() : configList.at(0);  // left hand
+            QString paramValue =
+                configList.size() < 1 ? QString() : configList.at(1);  // right hand
+
+            if (key == CH_LEVEL) {
                 level = Configuration::levelFromString(paramValue);
-            }
-            else if(key == CH_OUTPUT_TYPE)
-            {
-                if(paramValue.toUpper().contains("TEXT"))
-                {
+
+            } else if (key == CH_OUTPUT_TYPE) {
+                if (paramValue.toUpper().contains("TEXT")) {
                     outputType = Configuration::TEXTFILE;
-                }
-                else if(paramValue.toUpper().contains("XML"))
-                {
+
+                } else if (paramValue.toUpper().contains("XML")) {
                     outputType = Configuration::XMLFILE;
-                }
-                else
-                {
+
+                } else if (paramValue.toUpper().contains("SIGNAL")) {
+                    outputType = Configuration::SIGNAL;
+
+                } else {
                     outputType = Configuration::CONSOLE;
                 }
-            }
-            else if(key == CH_LOG_MASK)
-            {
+
+            } else if (key == CH_LOG_MASK) {
                 logMask = paramValue;
-            }
-			else if(key == CH_MAX_FILE_SIZE)
-            {
+
+            } else if (key == CH_MAX_FILE_SIZE) {
                 bool ok;
                 maxFileSize = paramValue.toInt(&ok);
-                if(!ok)
+
+                if (!ok) {
                     maxFileSize = 1000;
-            }
-			else if(key == CH_TIMESTAMP_FORMAT)
-            {
+                }
+
+            } else if (key == CH_TIMESTAMP_FORMAT) {
                 timestampFormat = paramValue;
-            }
-            else if(key == CH_FILE_NAME)
-            {
+
+            } else if (key == CH_FILE_NAME) {
                 fileName = paramValue;
-            }
-            else if(key == CH_FILE_NAME_TIMESTAMP)
-            {
+
+            } else if (key == CH_FILE_NAME_TIMESTAMP) {
                 fileNameTimestamp = paramValue;
-            }	
-            else if(key == CH_PATH)
-            {
+
+            } else if (key == CH_PATH) {
                 path = paramValue;
             }
         }
 
-        return new Configuration(owner, level, outputType, timestampFormat, logMask, fileName, fileNameTimestamp, path, maxFileSize);
+        return new Configuration(owner, level, outputType, timestampFormat, logMask,
+                                 fileName, fileNameTimestamp, path, maxFileSize);
     }
 
 public:
-
-    //! only public method, this will receive a hash by reference and fill it with found configurations
-    //! false will be returned if no config is filled in
-    inline static bool parseConfigurationFile(QList<Configuration*> &configs)//(QMultiHash<QString, Configuration*> &loggers)
-    {
+    //! only public method, this will receive a hash by reference and fill it with
+    //! found configurations false will be returned if no config is filled in
+    inline static bool parseConfigurationFile(
+        QList<Configuration *>
+        &configs) { //(QMultiHash<QString, Configuration*> &loggers)
         QMultiHash<QString, QString> ownerConfigLines;
-        QFile* file = new QFile(CH_CONFIG_FILE_NAME);
+        QFile *file = new QFile(CH_CONFIG_FILE_NAME);
+
         if (ConfigFileHandler::searchForConfigFile() &&
-                file->open(QIODevice::ReadOnly | QIODevice::Text))
-        {
+            file->open(QIODevice::ReadOnly | QIODevice::Text)) {
             QTextStream ts(file);
             QString configLine;
-            do
-            {
+
+            do {
                 configLine = ts.readLine();
-                if(!configLine.trimmed().isEmpty() && !configLine.trimmed().startsWith("#"))
-                {
-                    QStringList temp = configLine.split("."); // separate the owner.key=value
+
+                if (!configLine.trimmed().isEmpty() &&
+                    !configLine.trimmed().startsWith("#")) {
+                    QStringList temp =
+                        configLine.split(".");  // separate the owner.key=value
                     QString owner = temp.isEmpty() ? QString() : temp.at(0);
-                    if(!owner.isEmpty() && temp.size() > 1)
-                    {
+
+                    if (!owner.isEmpty() && temp.size() > 1) {
                         ownerConfigLines.insert(owner, temp.at(1));
                     }
                 }
             } while (!configLine.isNull());
-			file->close();
+
+            file->close();
             return createConfiguration(ownerConfigLines, configs);
-        }
-        else
-        {
+
+        } else {
             return false;
         }
     }
-
 };
 
-}
+}  // namespace qlogger
 
-#endif // CONFIGFILEHANDLER_H
+#endif  // CONFIGFILEHANDLER_H

--- a/configuration.cpp
+++ b/configuration.cpp
@@ -133,6 +133,11 @@ Configuration::Level Configuration::getLogLevel() const
     return logLevel;
 }
 
+void Configuration::setLogLevel(const Level lvl)
+{
+    logLevel = lvl;
+}
+
 Configuration::OutputType Configuration::getOutputType() const
 {
     return outputType;

--- a/configuration.cpp
+++ b/configuration.cpp
@@ -1,108 +1,121 @@
 /*
- * QLogger - A tiny Qt logging framework.
- *
- * MIT License
- * Copyright (c) 2013 sandro fadiga
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies
- * or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
- * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    QLogger - A tiny Qt logging framework.
+
+    MIT License
+    Copyright (c) 2013 sandro fadiga
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 */
 
 #include "configuration.h"
 
-namespace qlogger
-{
+namespace qlogger {
 
-Configuration::Configuration() :
-    logOwner(QString()), logLevel(Level(-1)), outputType(OutputType(-1)), outputLog(NULL), timestampFormat(QString())
-{
-}
+Configuration::Configuration()
+    : logOwner(QString()),
+      logLevel(Level(-1)),
+      outputType(OutputType(-1)),
+      outputLog(Q_NULLPTR),  // Changed NULL to Q_NULLPTR to avoid warning
+      timestampFormat(QString()) {}
 
-Configuration::Configuration(QString logOwner,
-              Configuration::Level lvl,
-              OutputType outputType,
-              QString timestampFormat,
-              QString logTextMask,
-              QString fileNameMask,
-              QString fileNameTimestampFormat,
-              QString filePath,
-              int fileMaxSizeInKb)
-    : logOwner(logOwner), logLevel(lvl), outputType(outputType), outputLog(NULL), timestampFormat(timestampFormat)
+Configuration::Configuration(QString logOwner, Configuration::Level lvl,
+                             OutputType outputType, QString timestampFormat,
+                             QString logTextMask, QString fileNameMask,
+                             QString fileNameTimestampFormat, QString filePath,
+                             int fileMaxSizeInKb)
+    : logOwner(logOwner),
+      logLevel(lvl),
+      outputType(outputType),
+      outputLog(Q_NULLPTR),  // Changed NULL to Q_NULLPTR to avoid warning
+      timestampFormat(timestampFormat)
 {
-
-    if(this->timestampFormat.isEmpty())
+    if (this->timestampFormat.isEmpty()) {
         this->timestampFormat = TIMESTAMP_QLOGGER_FORMAT;
+    }
 
-    switch(outputType)
-    {
-        case XMLFILE:
-            this->outputLog = new XmlOutput(logOwner, fileNameMask, fileNameTimestampFormat, filePath, fileMaxSizeInKb);
-            break;
-        case TEXTFILE:
-            this->outputLog = new TextFileOutput(logOwner, logTextMask, filePath, fileMaxSizeInKb, fileNameMask, fileNameTimestampFormat);
-            break;
-        case CONSOLE:
-        default:
-            this->outputLog = new ConsoleOutput(logTextMask);
+    switch (outputType) {
+    case XMLFILE:
+        this->outputLog =
+            new XmlOutput(logOwner, fileNameMask, fileNameTimestampFormat,
+                          filePath, fileMaxSizeInKb);
+        break;
+
+    case TEXTFILE:
+        this->outputLog =
+            new TextFileOutput(logOwner, logTextMask, filePath, fileMaxSizeInKb,
+                               fileNameMask, fileNameTimestampFormat);
+        break;
+
+    case SIGNAL: {
+        SignalOutput *sigOutput = new SignalOutput(logTextMask);
+        this->outputLog = sigOutput;
+        connect(sigOutput, &SignalOutput::logMessage,
+                this, &Configuration::logMessage);
+        break;
+    }
+
+    case CONSOLE:
+        //    default: // Not actually needed as all options used. Gives Warning
+        //    in QtCreator.
+        this->outputLog = new ConsoleOutput(logTextMask);
         break;
     }
 }
 
-Configuration::~Configuration()
-{
-}
+Configuration::~Configuration() {}
 
 bool Configuration::operator==(const Configuration &rh)
 {
-    return (this->logOwner == rh.logOwner && this->logLevel == rh.logLevel && this->outputType == rh.outputType);
+    return (this->logOwner == rh.logOwner && this->logLevel == rh.logLevel &&
+            this->outputType == rh.outputType);
 }
 
 QString Configuration::levelToString(const Level level)
 {
-    static const char* const buffer[] = { "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" };
+    static const char *const buffer[] = {"FATAL", "ERROR", "WARN",
+                                         "INFO",  "DEBUG", "TRACE"
+                                        };
     return buffer[level];
 }
 
 Configuration::Level Configuration::levelFromString(const QString level)
 {
     QString lvl = level.trimmed().toUpper();
-    if (lvl == "FATAL")
-    {
+
+    if (lvl == "FATAL") {
         return Configuration::q0FATAL;
-    }
-    else if (lvl == "WARN")
-    {
+
+    } else if (lvl == "WARN") {
         return Configuration::q2WARN;
-    }
-    else if (lvl == "INFO")
-    {
+
+    } else if (lvl == "INFO") {
         return Configuration::q3INFO;
-    }
-    else if (lvl == "DEBUG")
-    {
+
+    } else if (lvl == "DEBUG") {
         return Configuration::q4DEBUG;
-    }
-    else if (lvl == "TRACE")
-    {
+
+    } else if (lvl == "TRACE") {
         return Configuration::q5TRACE;
-    }
-    else // return default level
-    {
+
+    } else { // return default level
         return Configuration::q1ERROR;
     }
-
 }
 
 const QString Configuration::getLogOwner() const
@@ -125,7 +138,7 @@ Configuration::OutputType Configuration::getOutputType() const
     return outputType;
 }
 
-Output* Configuration::getOutputLog() const
+Output *Configuration::getOutputLog() const
 {
     return outputLog;
 }
@@ -135,4 +148,4 @@ const QString Configuration::getTimestampFormat() const
     return timestampFormat;
 }
 
-}
+}  // namespace qlogger

--- a/configuration.h
+++ b/configuration.h
@@ -105,6 +105,7 @@ public:
     const QString getLogOwner() const;
     void setLogOwner(const QString owner);
     Level getLogLevel() const;
+    void setLogLevel(const Level);
     Configuration::OutputType getOutputType() const;
     Output *getOutputLog() const;
     const QString getTimestampFormat() const;

--- a/configuration.h
+++ b/configuration.h
@@ -1,57 +1,58 @@
 /*
- * QLogger - A tiny Qt logging framework.
- *
- * MIT License
- * Copyright (c) 2013 sandro fadiga
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies
- * or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
- * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    QLogger - A tiny Qt logging framework.
+
+    MIT License
+    Copyright (c) 2013 sandro fadiga
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 */
 
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
-#include <QString>
-#include <QWeakPointer>
 #include "textoutput.h"
 #include "xmloutput.h"
+#include <QString>
+#include <QWeakPointer>
+#include <QObject>
 
-namespace qlogger
-{
+namespace qlogger {
 
 //!
 static const QString TIMESTAMP_QLOGGER_FORMAT = "MM/dd/yyyy hh:mm:ss";
 
 //! This class stores the configuration details for each log to be created.
 //! Default configuration can be created with the default constructor.
-class Configuration
-{
+class Configuration : public QObject {
+    Q_OBJECT
 public:
-
     // http://en.wikipedia.org/wiki/Java_logging_framework
     // http://commons.apache.org/logging/guide.html#Message%20Priorities/Levels
     //!
-    enum Level
-    {
-        q0FATAL, q1ERROR, q2WARN, q3INFO, q4DEBUG, q5TRACE
-    };
+    enum Level { q0FATAL, q1ERROR, q2WARN, q3INFO, q4DEBUG, q5TRACE };
 
     //!
-    enum OutputType
-    {
-        CONSOLE, TEXTFILE, XMLFILE
+    enum OutputType {
+        CONSOLE,
+        TEXTFILE,
+        XMLFILE,
+        SIGNAL,
     };
 
 public:
@@ -69,13 +70,19 @@ public:
     //! destructor, check for outputLog and closes it
     virtual ~Configuration();
 
-    //! equals operator is used to check if a configuration have the same level and output type only
+    //! equals operator is used to check if a configuration have the same level
+    //! and output type only
     bool operator==(const Configuration &rh);
+
+
 
     //! utility to convert the level enum to string
     static QString levelToString(const Configuration::Level level);
 
     static Configuration::Level levelFromString(const QString level);
+
+signals:
+    void logMessage(QString);
 
 private:
     //! store the name of the log owner to pass it to the output classes
@@ -88,9 +95,10 @@ private:
     OutputType outputType;
 
     //! this attribute is responsible for writing the log on the output
-    Output* outputLog;
+    Output *outputLog;
 
-    //! the date time format to be displayed on the log text it must use Qt Date Time format convention
+    //! the date time format to be displayed on the log text it must use Qt Date
+    //! Time format convention
     QString timestampFormat;
 
 public:
@@ -98,11 +106,10 @@ public:
     void setLogOwner(const QString owner);
     Level getLogLevel() const;
     Configuration::OutputType getOutputType() const;
-    Output* getOutputLog() const;
+    Output *getOutputLog() const;
     const QString getTimestampFormat() const;
-
 };
 
-}
+} // namespace qlogger
 
 #endif // CONFIGURATION_H

--- a/main.cpp
+++ b/main.cpp
@@ -27,9 +27,10 @@
 #include <QCoreApplication>
 #include <QApplication>
 
-#include <string>
+#include <string.h>
 
 #include "qlogger.h"
+#include "mainwindow.h"
 
 #include <QTime>
 #include <QRunnable>
@@ -154,23 +155,32 @@ void quickLogger()
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication a(argc, argv);
+    if (strncmp(argv[1], "SIGNAL", 6) == 0) {
+        QApplication a(argc, argv);
+        MainWindow w;
+        w.show();
 
-    //heavyLoadToFileTest();
+        return a.exec();
 
-    //threadHeavyLoadTest();
+    } else {
+        QCoreApplication a(argc, argv);
 
-    //sameLoggerMultiLevels();
+        //heavyLoadToFileTest();
 
-    //changeAllConfiguration();
+        //threadHeavyLoadTest();
 
-    //configFromFileTest();
+        //sameLoggerMultiLevels();
 
-    //overrideRootLoggerBehaviour();
+        //changeAllConfiguration();
 
-    quickLogger();
+        //configFromFileTest();
 
-    return a.exec();
+        //overrideRootLoggerBehaviour();
+
+        quickLogger();
+
+        return a.exec();
+    }
 }
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,30 +1,33 @@
 /*
- * QLogger - A tiny Qt logging framework.
- *
- * MIT License
- * Copyright (c) 2013 sandro fadiga
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies
- * or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
- * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    QLogger - A tiny Qt logging framework.
+
+    MIT License
+    Copyright (c) 2013 sandro fadiga
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge, publish, distribute,
+    sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+    is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+    AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 /*
- *  This is document / test program to show some of the QLogger capabilities.
- */
+    This is document / test program to show some of the QLogger capabilities.
+*/
 
 #include <QCoreApplication>
+#include <QApplication>
+
+#include <string>
 
 #include "qlogger.h"
 
@@ -34,28 +37,26 @@
 
 using namespace qlogger;
 
-class LoggerA : public QRunnable
-{
-    void run()
-    {
-        for(int i = 0 ; i < 1000000 ; i++)
+class LoggerA : public QRunnable {
+    void run() {
+        for (int i = 0 ; i < 1000000 ; i++) {
             QLOG_ERROR("Logger A speaking !", "threads");
+        }
     }
 };
-class LoggerB : public QRunnable
-{
-    void run()
-    {
-        for(int i = 0 ; i < 1000000 ; i++)
+class LoggerB : public QRunnable {
+    void run() {
+        for (int i = 0 ; i < 1000000 ; i++) {
             QLOG_FATAL("Logger B speaking !", "threads");
+        }
     }
 };
 
 void threadHeavyLoadTest()
 {
     QLogger::addLogger("threads");
-    LoggerA* loga = new LoggerA;
-    LoggerB* logb = new LoggerB;
+    LoggerA *loga = new LoggerA;
+    LoggerB *logb = new LoggerB;
     QThreadPool::globalInstance()->start(loga);
     QThreadPool::globalInstance()->start(logb);
 }
@@ -65,18 +66,19 @@ void heavyLoadToFileTest()
     qlogger::QLogger::addLogger("root", qlogger::Configuration::q2WARN, qlogger::Configuration::TEXTFILE);
     QLOG_FATAL(QString("start:%1").arg(QTime::currentTime().toString("mmss")));
     const int count = 1000000;
-    for (int i = 0; i != count; ++i)
-    {
+
+    for (int i = 0; i != count; ++i) {
         QLOG_INFO("this is not executed");
     }
+
     QLOG_FATAL(QString("end:").arg(QTime::currentTime().toString("mmss")));
 
     QLOG_FATAL(QString("start:%1").arg(QTime::currentTime().toString("mmss")));
 
-    for (int i = 0; i != count; ++i)
-    {
+    for (int i = 0; i != count; ++i) {
         QLOG_WARN("this is executed");
     }
+
     QLOG_FATAL(QString("end:").arg(QTime::currentTime().toString("mmss")));
 
     QLOG_INFO("fim", "teste");
@@ -89,17 +91,18 @@ void configFromFileTest()
     QLOG_ERROR("this will take a while");
 
     const int count = 500000;
-    for (int i = 0; i != count; ++i)
-    {
+
+    for (int i = 0; i != count; ++i) {
         QLOG_WARN("loaded a log from config and save to a file !!!!", "file");
         QLOG_ERROR("fatal log from config", "file");
         QLOG_FATAL("loaded a log config from a file", "file");
     }
-    for (int i = 0; i != 10; ++i)
-    {
-        QLOG_INFO("config from file, log to console","cons");
-        QLOG_TRACE("config from file, log to console","cons");
+
+    for (int i = 0; i != 10; ++i) {
+        QLOG_INFO("config from file, log to console", "cons");
+        QLOG_TRACE("config from file, log to console", "cons");
     }
+
     QLOG_ERROR("end of test, check for the files on c:");
 }
 
@@ -109,8 +112,8 @@ void sameLoggerMultiLevels()
     QLogger::addLogger("multilevel", Configuration::q0FATAL, Configuration::CONSOLE);
     QLogger::addLogger("multilevel", Configuration::q5TRACE, Configuration::TEXTFILE);
     const int count = 100;
-    for (int i = 0; i != count; ++i)
-    {
+
+    for (int i = 0; i != count; ++i) {
         QLOG_ERROR("will not be logged to console, but will to the file", "multilevel");
         QLOG_FATAL("will be logged to console and to the file", "multilevel");
         QLOG_WARN("will be logged only to the file", "multilevel")
@@ -119,16 +122,17 @@ void sameLoggerMultiLevels()
 
 void changeAllConfiguration()
 {
-    Configuration* cfg =
+    Configuration *cfg =
         new Configuration("config", Configuration::q3INFO, Configuration::TEXTFILE,
                           "dd-MM-yyyy hh:mm:ss", "%t [%l] <%o> : %m",
                           "myfile_%3_%2_%1.log", "ddMMyyyy_hhmmss", "c:\\", 10000);
     QLogger::addLogger(cfg);
     const int count = 100;
-    for (int i = 0; i != count; ++i)
-    {
+
+    for (int i = 0; i != count; ++i) {
         QLOG_WARN("this will be saved on a file at c:", "config");
     }
+
     QLOG_FATAL("end of this test");
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -10,32 +10,51 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
-    p_current_btn = ui->pDebugBtn;
-
-    p_display_status_lbl = new QLabel(this);
-    ui->pStatusBar->addPermanentWidget(p_display_status_lbl, 0);
-    p_logging_status_lbl = new QLabel(this);
-    ui->pStatusBar->addPermanentWidget(p_logging_status_lbl, 1);
+    p_current_msg_btn = ui->pDebugBtn;
+    p_current_logging_btn = ui->pLogDebugBtn;
 
     // QLogger configurations
-    //    QLogger::addLogger("sigs", Configuration::q0FATAL, Configuration::SIGNAL);
-    //    QLogger::addLogger("sigs", Configuration::q1ERROR, Configuration::SIGNAL);
-    //    QLogger::addLogger("fatal", Configuration::q2WARN, Configuration::SIGNAL);
-    //    QLogger::addLogger("sigs", Configuration::q3INFO, Configuration::SIGNAL);
     QLogger::addLogger("sigs", Configuration::q4DEBUG, Configuration::SIGNAL);
-    //    QLogger::addLogger("sigs", Configuration::q5TRACE, Configuration::SIGNAL);
 
     // QLogger signals => QWidget links
     connect(QLogger::getInstance(), &QLogger::logMessage,
             ui->pErrorsDisplay, &QPlainTextEdit::appendPlainText);
 
+
+    QString status_style = "QLabel {"
+                           "border: 2px solid black;"
+                           "background: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #eef, stop: 1 #ccf);"
+                           "}";
+
+    p_msg_status_lbl = new QLabel(this);
+    p_msg_status_lbl->setStyleSheet(status_style);
+    ui->pStatusBar->addPermanentWidget(p_msg_status_lbl, 0);
+    setMessageLogLevel(Configuration::q4DEBUG);
+
+    p_logging_status_lbl = new QLabel(this);
+    p_logging_status_lbl->setStyleSheet(status_style);
+    ui->pStatusBar->addPermanentWidget(p_logging_status_lbl, 1);
+    setLoggingLogLevel(Configuration::q4DEBUG);
+
+    QLabel *filler = new QLabel();
+    ui->pStatusBar->addPermanentWidget(filler, 2);
+
+
     // ui setup.
-    connect(ui->pFatalBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
-    connect(ui->pErrorBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
-    connect(ui->pDebugBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
-    connect(ui->pInfoBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
-    connect(ui->pWarnBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
-    connect(ui->pTraceBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
+    connect(ui->pFatalBtn, &QRadioButton::clicked, this, &MainWindow::msgLevelBtnsClicked);
+    connect(ui->pErrorBtn, &QRadioButton::clicked, this, &MainWindow::msgLevelBtnsClicked);
+    connect(ui->pDebugBtn, &QRadioButton::clicked, this, &MainWindow::msgLevelBtnsClicked);
+    connect(ui->pInfoBtn, &QRadioButton::clicked, this, &MainWindow::msgLevelBtnsClicked);
+    connect(ui->pWarnBtn, &QRadioButton::clicked, this, &MainWindow::msgLevelBtnsClicked);
+    connect(ui->pTraceBtn, &QRadioButton::clicked, this, &MainWindow::msgLevelBtnsClicked);
+
+    connect(ui->pLogFatalBtn, &QRadioButton::clicked, this, &MainWindow::loggingLevelBtnsClicked);
+    connect(ui->pLogErrorBtn, &QRadioButton::clicked, this, &MainWindow::loggingLevelBtnsClicked);
+    connect(ui->pLogDebugBtn, &QRadioButton::clicked, this, &MainWindow::loggingLevelBtnsClicked);
+    connect(ui->pLogInfoBtn, &QRadioButton::clicked, this, &MainWindow::loggingLevelBtnsClicked);
+    connect(ui->pLogWarnBtn, &QRadioButton::clicked, this, &MainWindow::loggingLevelBtnsClicked);
+    connect(ui->pLogTraceBtn, &QRadioButton::clicked, this, &MainWindow::loggingLevelBtnsClicked);
+
     connect(ui->pSendBtn, &QPushButton::clicked, this, &MainWindow::sendBtnClicked);
 
     //    sendMessage("Inital message - should be debug.");
@@ -46,99 +65,145 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
-void MainWindow::setDisplayLogLevel(MainWindow::Level level)
+void MainWindow::setMessageLogLevel(Configuration::Level level)
 {
-    if (level == FATAL) {
-        m_log_level = FATAL;
-        p_display_status_lbl->setText("Log level : FATAL");
+    if (level == Configuration::q0FATAL) {
+        m_msg_level = Configuration::q0FATAL;
+        ui->pFatalBtn->setChecked(true);
+        p_msg_status_lbl->setText("Message level : FATAL");
 
-    } else if (level == ERROR) {
-        m_log_level = ERROR;
-        p_display_status_lbl->setText("Log level : ERROR");
+    } else if (level == Configuration::q1ERROR) {
+        m_msg_level = Configuration::q1ERROR;
+        ui->pErrorBtn->setChecked(true);
+        p_msg_status_lbl->setText("Message level : ERROR");
 
-    } else if (level == DEBUG) {
-        m_log_level = DEBUG;
-        p_display_status_lbl->setText("Log level : DEBUG");
+    } else if (level == Configuration::q2WARN) {
+        m_msg_level = Configuration::q2WARN;
+        ui->pWarnBtn->setChecked(true);
+        p_msg_status_lbl->setText("Message level : WARN");
 
-    } else if (level == INFO) {
-        m_log_level = INFO;
-        p_display_status_lbl->setText("Log level : INFO");
+    } else if (level == Configuration::q3INFO) {
+        m_msg_level = Configuration::q3INFO;
+        ui->pInfoBtn->setChecked(true);
+        p_msg_status_lbl->setText("Message level : INFO");
 
-    } else if (level == WARN) {
-        m_log_level = WARN;
-        p_display_status_lbl->setText("Log level : WARN");
+    } else if (level == Configuration::q4DEBUG) {
+        m_msg_level = Configuration::q4DEBUG;
+        ui->pDebugBtn->setChecked(true);
+        p_msg_status_lbl->setText("Message level : DEBUG");
 
-    } else if (level == TRACE) {
-        m_log_level = TRACE;
-        p_display_status_lbl->setText("Log level : TRACE");
+    } else if (level == Configuration::q5TRACE) {
+        m_msg_level = Configuration::q5TRACE;
+        ui->pTraceBtn->setChecked(true);
+        p_msg_status_lbl->setText("Message level : TRACE");
     }
 }
 
-void MainWindow::setLoggingLogLevel(MainWindow::Level level)
+void MainWindow::setLoggingLogLevel(Configuration::Level level)
 {
-    if (level == FATAL) {
-        m_log_level = FATAL;
+    if (level == Configuration::q0FATAL) {
+        m_log_level = Configuration::q0FATAL;
+        ui->pLogFatalBtn->setChecked(true);
         p_logging_status_lbl->setText("Log level : FATAL");
+        QLogger::changelogLevel("sigs", Configuration::q0FATAL, Configuration::SIGNAL);
 
-    } else if (level == ERROR) {
-        m_log_level = ERROR;
+    } else if (level == Configuration::q1ERROR) {
+        m_log_level = Configuration::q1ERROR;
+        ui->pLogErrorBtn->setChecked(true);
         p_logging_status_lbl->setText("Log level : ERROR");
+        QLogger::changelogLevel("sigs", Configuration::q1ERROR, Configuration::SIGNAL);
 
-    } else if (level == DEBUG) {
-        m_log_level = DEBUG;
-        p_logging_status_lbl->setText("Log level : DEBUG");
-
-    } else if (src == ui->pInfoBtn) {
-        m_log_level = INFO;
-        p_logging_status_lbl->setText("Log level : INFO");
-
-    } else if (src == ui->pWarnBtn) {
-        m_log_level = WARN;
+    } else if (level == Configuration::q2WARN) {
+        m_log_level = Configuration::q2WARN;
+        ui->pLogWarnBtn->setChecked(true);
         p_logging_status_lbl->setText("Log level : WARN");
+        QLogger::changelogLevel("sigs", Configuration::q2WARN, Configuration::SIGNAL);
 
-    } else if (src == ui->pTraceBtn) {
-        m_log_level = TRACE;
+    } else if (level == Configuration::q3INFO) {
+        m_log_level = Configuration::q3INFO;
+        ui->pLogInfoBtn->setChecked(true);
+        p_logging_status_lbl->setText("Log level : INFO");
+        QLogger::changelogLevel("sigs", Configuration::q3INFO, Configuration::SIGNAL);
+
+    } else if (level == Configuration::q4DEBUG) {
+        m_log_level = Configuration::q4DEBUG;
+        ui->pLogDebugBtn->setChecked(true);
+        p_logging_status_lbl->setText("Log level : DEBUG");
+        QLogger::changelogLevel("sigs", Configuration::q4DEBUG, Configuration::SIGNAL);
+
+    } else if (level == Configuration::q5TRACE) {
+        m_log_level = Configuration::q5TRACE;
+        ui->pLogTraceBtn->setChecked(true);
         p_logging_status_lbl->setText("Log level : TRACE");
+        QLogger::changelogLevel("sigs", Configuration::q5TRACE, Configuration::SIGNAL);
     }
 }
 
-void MainWindow::levelBtnsClicked()
+void MainWindow::msgLevelBtnsClicked()
 {
     QObject *src = sender();
 
-    if (src == p_current_btn) {
+    if (src == p_current_logging_btn) {
         return;
 
     } else if (src == ui->pFatalBtn) {
-        m_level = FATAL;
-        p_current_btn = ui->pFatalBtn;
-        p_display_status_lbl->setText("Log level : FATAL");
+        setMessageLogLevel(Configuration::q0FATAL);
+        p_current_msg_btn = ui->pFatalBtn;
 
     } else if (src == ui->pErrorBtn) {
-        m_level = ERROR;
-        p_current_btn = ui->pErrorBtn;
-        p_display_status_lbl->setText("Log level : ERROR");
-
-    } else if (src == ui->pDebugBtn) {
-        m_level = DEBUG;
-        p_current_btn = ui->pDebugBtn;
-        p_display_status_lbl->setText("Log level : DEBUG");
-
-    } else if (src == ui->pInfoBtn) {
-        m_level = INFO;
-        p_current_btn = ui->pInfoBtn;
-        p_display_status_lbl->setText("Log level : INFO");
+        setMessageLogLevel(Configuration::q1ERROR);
+        p_current_msg_btn = ui->pErrorBtn;
 
     } else if (src == ui->pWarnBtn) {
-        m_level = WARN;
-        p_current_btn = ui->pWarnBtn;
-        p_display_status_lbl->setText("Log level : WARN");
+        setMessageLogLevel(Configuration::q2WARN);
+        p_current_msg_btn = ui->pWarnBtn;
+
+    } else if (src == ui->pInfoBtn) {
+        setMessageLogLevel(Configuration::q3INFO);
+        p_current_msg_btn = ui->pInfoBtn;
+
+    } else if (src == ui->pDebugBtn) {
+        setMessageLogLevel(Configuration::q4DEBUG);
+        p_current_msg_btn = ui->pDebugBtn;
 
     } else if (src == ui->pTraceBtn) {
-        m_level = TRACE;
-        p_current_btn = ui->pTraceBtn;
-        p_display_status_lbl->setText("Log level : TRACE");
+        setMessageLogLevel(Configuration::q5TRACE);
+        p_current_msg_btn = ui->pTraceBtn;
     }
+}
+
+void MainWindow::loggingLevelBtnsClicked()
+{
+    QObject *src = sender();
+
+    if (src == p_current_logging_btn) {
+        return;
+
+    } else if (src == ui->pLogFatalBtn) {
+        setLoggingLogLevel(Configuration::q0FATAL);
+        p_current_logging_btn = ui->pLogFatalBtn;
+
+    } else if (src == ui->pLogErrorBtn) {
+        setLoggingLogLevel(Configuration::q1ERROR);
+        p_current_logging_btn = ui->pLogErrorBtn;
+
+    } else if (src == ui->pLogWarnBtn) {
+        setLoggingLogLevel(Configuration::q2WARN);
+        p_current_logging_btn = ui->pLogWarnBtn;
+
+    } else if (src == ui->pLogInfoBtn) {
+        setLoggingLogLevel(Configuration::q3INFO);
+        p_current_logging_btn = ui->pLogInfoBtn;
+
+    } else if (src == ui->pLogDebugBtn) {
+        setLoggingLogLevel(Configuration::q4DEBUG);
+        p_current_logging_btn = ui->pLogDebugBtn;
+
+    } else if (src == ui->pLogTraceBtn) {
+        setLoggingLogLevel(Configuration::q5TRACE);
+        p_current_logging_btn = ui->pLogTraceBtn;
+    }
+
 }
 
 void MainWindow::sendBtnClicked()
@@ -148,28 +213,28 @@ void MainWindow::sendBtnClicked()
 
 void MainWindow::sendMessage(QString msg)
 {
-    switch (m_level) {
-    case FATAL:
+    switch (m_msg_level) {
+    case Configuration::q0FATAL:
         QLOG_FATAL(msg, "sigs");
         break;
 
-    case ERROR:
+    case Configuration::q1ERROR:
         QLOG_ERROR(msg, "sigs");
         break;
 
-    case WARN:
+    case Configuration::q2WARN:
         QLOG_WARN(msg, "sigs");
         break;
 
-    case DEBUG:
-        QLOG_DEBUG(msg, "sigs");
-        break;
-
-    case INFO:
+    case Configuration::q3INFO:
         QLOG_INFO(msg, "sigs");
         break;
 
-    case TRACE:
+    case Configuration::q4DEBUG:
+        QLOG_DEBUG(msg, "sigs");
+        break;
+
+    case Configuration::q5TRACE:
         QLOG_TRACE(msg, "sigs");
         break;
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,0 +1,116 @@
+#include "mainwindow.h"
+#include "ui_mainwindow.h"
+
+#include "qlogger.h"
+
+using namespace qlogger;
+
+MainWindow::MainWindow(QWidget *parent) :
+    QMainWindow(parent),
+    ui(new Ui::MainWindow)
+{
+    ui->setupUi(this);
+    p_current_btn = ui->pDebugBtn;
+
+    // QLogger configurations
+    //    QLogger::addLogger("sigs", Configuration::q0FATAL, Configuration::SIGNAL);
+    //    QLogger::addLogger("sigs", Configuration::q1ERROR, Configuration::SIGNAL);
+    QLogger::addLogger("fatal", Configuration::q2WARN, Configuration::SIGNAL);
+    //    QLogger::addLogger("sigs", Configuration::q3INFO, Configuration::SIGNAL);
+    //    QLogger::addLogger("sigs", Configuration::q4DEBUG, Configuration::SIGNAL);
+    //    QLogger::addLogger("sigs", Configuration::q5TRACE, Configuration::SIGNAL);
+
+    // QLogger signals => QWidget links
+    connect(QLogger::getInstance(), &QLogger::logMessage,
+            ui->pFatalErrors, &QPlainTextEdit::appendPlainText);
+
+    // ui setup.
+    connect(ui->pFatalBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
+    connect(ui->pErrorBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
+    connect(ui->pDebugBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
+    connect(ui->pInfoBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
+    connect(ui->pWarnBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
+    connect(ui->pTraceBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
+    connect(ui->pSendBtn, &QPushButton::clicked, this, &MainWindow::sendBtnClicked);
+
+    //    sendMessage("Inital message - should be debug.");
+}
+
+MainWindow::~MainWindow()
+{
+    delete ui;
+}
+
+void MainWindow::levelBtnsClicked()
+{
+    QObject *src = sender();
+
+    if (src == p_current_btn) {
+        return;
+
+    } else if (src == ui->pFatalBtn) {
+        m_level = FATAL;
+        p_current_btn = ui->pFatalBtn;
+        //        sendMessage("Level changed to FATAL");
+
+    } else if (src == ui->pErrorBtn) {
+        m_level = ERROR;
+        p_current_btn = ui->pErrorBtn;
+        //        sendMessage("Level changed to ERROR");
+
+    } else if (src == ui->pDebugBtn) {
+        m_level = DEBUG;
+        p_current_btn = ui->pDebugBtn;
+        //        sendMessage("Level changed to DEBUG");
+
+    } else if (src == ui->pInfoBtn) {
+        m_level = INFO;
+        p_current_btn = ui->pInfoBtn;
+        //        sendMessage("Level changed to INFO");
+
+    } else if (src == ui->pWarnBtn) {
+        m_level = WARN;
+        p_current_btn = ui->pWarnBtn;
+        //        sendMessage("Level changed to WARN");
+
+    } else if (src == ui->pTraceBtn) {
+        m_level = TRACE;
+        p_current_btn = ui->pTraceBtn;
+        //        sendMessage("Level changed to TRACE");
+    }
+}
+
+void MainWindow::sendBtnClicked()
+{
+    sendMessage("The send button was clicked at set level.");
+}
+
+void MainWindow::sendMessage(QString msg)
+{
+    switch (m_level) {
+    case FATAL:
+        QLOG_FATAL(msg, "sigs");
+        break;
+
+    case ERROR:
+        QLOG_ERROR(msg, "sigs");
+        break;
+
+    case WARN:
+        QLOG_WARN(msg, "sigs");
+        break;
+
+    case DEBUG:
+        QLOG_DEBUG(msg, "sigs");
+        break;
+
+    case INFO:
+        QLOG_INFO(msg, "sigs");
+        break;
+
+    case TRACE:
+        QLOG_TRACE(msg, "sigs");
+        break;
+    }
+}
+

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -12,17 +12,22 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     p_current_btn = ui->pDebugBtn;
 
+    p_display_status_lbl = new QLabel(this);
+    ui->pStatusBar->addPermanentWidget(p_display_status_lbl, 0);
+    p_logging_status_lbl = new QLabel(this);
+    ui->pStatusBar->addPermanentWidget(p_logging_status_lbl, 1);
+
     // QLogger configurations
     //    QLogger::addLogger("sigs", Configuration::q0FATAL, Configuration::SIGNAL);
     //    QLogger::addLogger("sigs", Configuration::q1ERROR, Configuration::SIGNAL);
-    QLogger::addLogger("fatal", Configuration::q2WARN, Configuration::SIGNAL);
+    //    QLogger::addLogger("fatal", Configuration::q2WARN, Configuration::SIGNAL);
     //    QLogger::addLogger("sigs", Configuration::q3INFO, Configuration::SIGNAL);
-    //    QLogger::addLogger("sigs", Configuration::q4DEBUG, Configuration::SIGNAL);
+    QLogger::addLogger("sigs", Configuration::q4DEBUG, Configuration::SIGNAL);
     //    QLogger::addLogger("sigs", Configuration::q5TRACE, Configuration::SIGNAL);
 
     // QLogger signals => QWidget links
     connect(QLogger::getInstance(), &QLogger::logMessage,
-            ui->pFatalErrors, &QPlainTextEdit::appendPlainText);
+            ui->pErrorsDisplay, &QPlainTextEdit::appendPlainText);
 
     // ui setup.
     connect(ui->pFatalBtn, &QRadioButton::clicked, this, &MainWindow::levelBtnsClicked);
@@ -41,6 +46,62 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
+void MainWindow::setDisplayLogLevel(MainWindow::Level level)
+{
+    if (level == FATAL) {
+        m_log_level = FATAL;
+        p_display_status_lbl->setText("Log level : FATAL");
+
+    } else if (level == ERROR) {
+        m_log_level = ERROR;
+        p_display_status_lbl->setText("Log level : ERROR");
+
+    } else if (level == DEBUG) {
+        m_log_level = DEBUG;
+        p_display_status_lbl->setText("Log level : DEBUG");
+
+    } else if (level == INFO) {
+        m_log_level = INFO;
+        p_display_status_lbl->setText("Log level : INFO");
+
+    } else if (level == WARN) {
+        m_log_level = WARN;
+        p_display_status_lbl->setText("Log level : WARN");
+
+    } else if (level == TRACE) {
+        m_log_level = TRACE;
+        p_display_status_lbl->setText("Log level : TRACE");
+    }
+}
+
+void MainWindow::setLoggingLogLevel(MainWindow::Level level)
+{
+    if (level == FATAL) {
+        m_log_level = FATAL;
+        p_logging_status_lbl->setText("Log level : FATAL");
+
+    } else if (level == ERROR) {
+        m_log_level = ERROR;
+        p_logging_status_lbl->setText("Log level : ERROR");
+
+    } else if (level == DEBUG) {
+        m_log_level = DEBUG;
+        p_logging_status_lbl->setText("Log level : DEBUG");
+
+    } else if (src == ui->pInfoBtn) {
+        m_log_level = INFO;
+        p_logging_status_lbl->setText("Log level : INFO");
+
+    } else if (src == ui->pWarnBtn) {
+        m_log_level = WARN;
+        p_logging_status_lbl->setText("Log level : WARN");
+
+    } else if (src == ui->pTraceBtn) {
+        m_log_level = TRACE;
+        p_logging_status_lbl->setText("Log level : TRACE");
+    }
+}
+
 void MainWindow::levelBtnsClicked()
 {
     QObject *src = sender();
@@ -51,32 +112,32 @@ void MainWindow::levelBtnsClicked()
     } else if (src == ui->pFatalBtn) {
         m_level = FATAL;
         p_current_btn = ui->pFatalBtn;
-        //        sendMessage("Level changed to FATAL");
+        p_display_status_lbl->setText("Log level : FATAL");
 
     } else if (src == ui->pErrorBtn) {
         m_level = ERROR;
         p_current_btn = ui->pErrorBtn;
-        //        sendMessage("Level changed to ERROR");
+        p_display_status_lbl->setText("Log level : ERROR");
 
     } else if (src == ui->pDebugBtn) {
         m_level = DEBUG;
         p_current_btn = ui->pDebugBtn;
-        //        sendMessage("Level changed to DEBUG");
+        p_display_status_lbl->setText("Log level : DEBUG");
 
     } else if (src == ui->pInfoBtn) {
         m_level = INFO;
         p_current_btn = ui->pInfoBtn;
-        //        sendMessage("Level changed to INFO");
+        p_display_status_lbl->setText("Log level : INFO");
 
     } else if (src == ui->pWarnBtn) {
         m_level = WARN;
         p_current_btn = ui->pWarnBtn;
-        //        sendMessage("Level changed to WARN");
+        p_display_status_lbl->setText("Log level : WARN");
 
     } else if (src == ui->pTraceBtn) {
         m_level = TRACE;
         p_current_btn = ui->pTraceBtn;
-        //        sendMessage("Level changed to TRACE");
+        p_display_status_lbl->setText("Log level : TRACE");
     }
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -1,0 +1,34 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+#include <QRadioButton>
+
+#include "configuration.h"
+
+namespace Ui {
+class MainWindow;
+}
+
+class MainWindow : public QMainWindow {
+    Q_OBJECT
+
+public:
+    explicit MainWindow(QWidget *parent = Q_NULLPTR);
+    ~MainWindow();
+
+protected:
+    enum Level {
+        FATAL, ERROR, WARN, INFO, DEBUG, TRACE,
+    };
+    void levelBtnsClicked();
+    void sendBtnClicked();
+    void sendMessage(QString msg);
+
+private:
+    Ui::MainWindow *ui;
+    QRadioButton *p_current_btn;
+    Level m_level = DEBUG;
+};
+
+#endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QRadioButton>
+#include <QLabel>
 
 #include "configuration.h"
 
@@ -21,14 +22,18 @@ protected:
     enum Level {
         FATAL, ERROR, WARN, INFO, DEBUG, TRACE,
     };
+    QLabel *p_display_status_lbl, *p_logging_status_lbl;
+    QRadioButton *p_current_btn;
+    Level m_level = DEBUG, m_log_level = DEBUG;
+
+    void setDisplayLogLevel(Level);
+    void setLoggingLogLevel(Level);
     void levelBtnsClicked();
     void sendBtnClicked();
     void sendMessage(QString msg);
 
 private:
     Ui::MainWindow *ui;
-    QRadioButton *p_current_btn;
-    Level m_level = DEBUG;
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -19,16 +19,14 @@ public:
     ~MainWindow();
 
 protected:
-    enum Level {
-        FATAL, ERROR, WARN, INFO, DEBUG, TRACE,
-    };
-    QLabel *p_display_status_lbl, *p_logging_status_lbl;
-    QRadioButton *p_current_btn;
-    Level m_level = DEBUG, m_log_level = DEBUG;
+    QLabel *p_msg_status_lbl, *p_logging_status_lbl;
+    QRadioButton *p_current_msg_btn, *p_current_logging_btn;
+    qlogger::Configuration::Level m_log_level = qlogger::Configuration::q4DEBUG, m_msg_level = qlogger::Configuration::q4DEBUG;
 
-    void setDisplayLogLevel(Level);
-    void setLoggingLogLevel(Level);
-    void levelBtnsClicked();
+    void setMessageLogLevel(qlogger::Configuration::Level);
+    void setLoggingLogLevel(qlogger::Configuration::Level);
+    void msgLevelBtnsClicked();
+    void loggingLevelBtnsClicked();
     void sendBtnClicked();
     void sendMessage(QString msg);
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -18,7 +18,7 @@
     <item row="1" column="0">
      <widget class="QGroupBox" name="groupBox">
       <property name="title">
-       <string>Display Level :</string>
+       <string>Message Level</string>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
@@ -115,6 +115,9 @@
          <property name="text">
           <string>Debug</string>
          </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -130,7 +133,7 @@
     <item row="2" column="0" colspan="3">
      <widget class="QPushButton" name="pSendBtn">
       <property name="text">
-       <string>Send</string>
+       <string>Send Message</string>
       </property>
      </widget>
     </item>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -15,17 +15,10 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QGridLayout" name="gridLayout">
-    <item row="2" column="1">
-     <widget class="QPushButton" name="pSendBtn">
-      <property name="text">
-       <string>Send</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1" rowspan="2">
+    <item row="1" column="0">
      <widget class="QGroupBox" name="groupBox">
       <property name="title">
-       <string>Level to display :</string>
+       <string>Display Level :</string>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
@@ -52,7 +45,7 @@
        <item>
         <widget class="QRadioButton" name="pInfoBtn">
          <property name="text">
-          <string>Info</string>
+          <string>I&amp;nfo</string>
          </property>
         </widget>
        </item>
@@ -76,10 +69,68 @@
       </layout>
      </widget>
     </item>
-    <item row="0" column="0" rowspan="3">
-     <widget class="QPlainTextEdit" name="pFatalErrors">
+    <item row="1" column="1">
+     <widget class="QPlainTextEdit" name="pErrorsDisplay">
       <property name="plainText">
        <string/>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="2">
+     <widget class="QGroupBox" name="groupBox_2">
+      <property name="title">
+       <string>Log Level :</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QRadioButton" name="pLogFatalBtn">
+         <property name="text">
+          <string>Fatal</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pLogErrorBtn">
+         <property name="text">
+          <string>Error</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pLogWarnBtn">
+         <property name="text">
+          <string>Warn</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pLogInfoBtn">
+         <property name="text">
+          <string>Info</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pLogDebugBtn">
+         <property name="text">
+          <string>Debug</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pLogTraceBtn">
+         <property name="text">
+          <string>Trace</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="2" column="0" colspan="3">
+     <widget class="QPushButton" name="pSendBtn">
+      <property name="text">
+       <string>Send</string>
       </property>
      </widget>
     </item>
@@ -103,7 +154,7 @@
     <bool>false</bool>
    </attribute>
   </widget>
-  <widget class="QStatusBar" name="statusBar"/>
+  <widget class="QStatusBar" name="pStatusBar"/>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources/>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1114</width>
+    <height>570</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="2" column="1">
+     <widget class="QPushButton" name="pSendBtn">
+      <property name="text">
+       <string>Send</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1" rowspan="2">
+     <widget class="QGroupBox" name="groupBox">
+      <property name="title">
+       <string>Level to display :</string>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QRadioButton" name="pFatalBtn">
+         <property name="text">
+          <string>Fatal</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pErrorBtn">
+         <property name="text">
+          <string>Error</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pWarnBtn">
+         <property name="text">
+          <string>Warn</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pInfoBtn">
+         <property name="text">
+          <string>Info</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pDebugBtn">
+         <property name="text">
+          <string>Debug</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="pTraceBtn">
+         <property name="text">
+          <string>Trace</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="0" column="0" rowspan="3">
+     <widget class="QPlainTextEdit" name="pFatalErrors">
+      <property name="plainText">
+       <string/>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menuBar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>1114</width>
+     <height>28</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QToolBar" name="mainToolBar">
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
+  <widget class="QStatusBar" name="statusBar"/>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/qlogger.cfg
+++ b/qlogger.cfg
@@ -33,3 +33,7 @@ file.path=c:\
 cons.level=trace
 cons.outputType=console
 cons.logMask=time:%t owner:%o level:%l function:%f line:%n message:%m
+
+#
+sig.level=warn
+sig.outputType=SIGNAL

--- a/qlogger.cfg
+++ b/qlogger.cfg
@@ -22,18 +22,18 @@
 
 # line comment 
 
-# first configuration will log to warn level to a file on c:\ with 10Mb of size 
-file.level=warn
-file.outputType=text
-# 10mb file
-file.maxFileSize=10000
-file.path=c:\
+## first configuration will log to warn level to a file on c:\ with 10Mb of size
+#file.level=warn
+#file.outputType=text
+## 10mb file
+#file.maxFileSize=10000
+#file.path=c:\
 
-# second config will log to console with trace level and customized log text mask 
-cons.level=trace
-cons.outputType=console
-cons.logMask=time:%t owner:%o level:%l function:%f line:%n message:%m
+## second config will log to console with trace level and customized log text mask
+#cons.level=trace
+#cons.outputType=console
+#cons.logMask=time:%t owner:%o level:%l function:%f line:%n message:%m
 
 #
-sig.level=warn
+sig.level=trace
 sig.outputType=SIGNAL

--- a/qlogger.cpp
+++ b/qlogger.cpp
@@ -156,6 +156,23 @@ void QLogger::log(Configuration::Level lvl, QString message, QString functionNam
     writex.unlock();
 }
 
+void QLogger::changelogLevel(QString owner, Configuration::Level lvl, Configuration::OutputType outputType)
+{
+    writex.lock();
+    QList<Configuration *> configs = QLogger::getInstance()->loggers.values(owner);
+    const int size = configs.size();
+
+    for (int i = 0 ; i < size ; i++) {
+        Configuration *cfg = configs.at(i);
+
+        if (cfg->getOutputType() == outputType) {
+            cfg->setLogLevel(lvl);
+        }
+    }
+
+    writex.unlock();
+}
+
 
 
 }

--- a/qlogger.cpp
+++ b/qlogger.cpp
@@ -87,6 +87,11 @@ QLogger *QLogger::getInstance()
             for (int i = 0 ; i < size ; i++) {
                 Configuration *config = lst.at(i);
                 QLogger::getPointerInstance()->loggers.insert(config->getLogOwner(), config);
+
+                if (config->getOutputType() == Configuration::SIGNAL) {
+                    connect(config, &Configuration::logMessage,
+                            QLogger::getPointerInstance(), &QLogger::logMessage);
+                }
             }
         }
 

--- a/qlogger.cpp
+++ b/qlogger.cpp
@@ -1,23 +1,23 @@
 /*
- * QLogger - A tiny Qt logging framework.
- *
- * MIT License
- * Copyright (c) 2013 sandro fadiga
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies
- * or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
- * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    QLogger - A tiny Qt logging framework.
+
+    MIT License
+    Copyright (c) 2013 sandro fadiga
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+    and associated documentation files (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge, publish, distribute,
+    sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+    is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+    AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 #include "qlogger.h"
@@ -27,8 +27,7 @@
 
 #include "configfilehandler.h"
 
-namespace qlogger
-{
+namespace qlogger {
 
 QAtomicPointer<QLogger> QLogger::instance = 0;
 QLoggerDestroyer QLogger::destroyer;
@@ -43,8 +42,8 @@ QLoggerDestroyer::QLoggerDestroyer(QAtomicPointer<QLogger> s)
 QLoggerDestroyer::~QLoggerDestroyer()
 {
     QLogger::mutex.lock();
-	// call the close file methods for all loggers
-	QLoggerDestroyer::getPointerInstance()->close();
+    // call the close file methods for all loggers
+    QLoggerDestroyer::getPointerInstance()->close();
     delete QLoggerDestroyer::getPointerInstance();
     QLogger::mutex.unlock();
 }
@@ -62,53 +61,60 @@ QLogger::~QLogger()
 
 void QLogger::close()
 {
-    QList<Configuration*> cfgList = loggers.values();
+    QList<Configuration *> cfgList = loggers.values();
     const int size = cfgList.size();
-    for (int i = 0 ; i < size ; i++)
-	{
-		Configuration* cfg = cfgList.at(i);
+
+    for (int i = 0 ; i < size ; i++) {
+        Configuration *cfg = cfgList.at(i);
         cfg->getOutputLog()->close();
-	}
+    }
 }
 
-QLogger* QLogger::getInstance()
+QLogger *QLogger::getInstance()
 {
-	if(!QLogger::getPointerInstance())
-    {
+    if (!QLogger::getPointerInstance()) {
         mutex.lock();
-        if (instance.testAndSetOrdered(0, new QLogger()))
-        {
+
+        if (instance.testAndSetOrdered(0, new QLogger())) {
             destroyer.SetSingleton(instance);
-			QList<Configuration*> lst;
-			//add the default "root" logger
-			lst.append(new Configuration("root", Configuration::q1ERROR));
-			// configuration file read, then start with the default logger
-			ConfigFileHandler::parseConfigurationFile(lst);//QLogger::getPointerInstance()->loggers);
-			int size =  lst.size();
-			for(int i = 0 ; i < size ; i++)
-			{
-				Configuration* config = lst.at(i);
-				QLogger::getPointerInstance()->loggers.insert(config->getLogOwner(), config);
-			}
+            QList<Configuration *> lst;
+            //add the default "root" logger
+            lst.append(new Configuration("root", Configuration::q1ERROR));
+            // configuration file read, then start with the default logger
+            ConfigFileHandler::parseConfigurationFile(lst);//QLogger::getPointerInstance()->loggers);
+            int size =  lst.size();
+
+            for (int i = 0 ; i < size ; i++) {
+                Configuration *config = lst.at(i);
+                QLogger::getPointerInstance()->loggers.insert(config->getLogOwner(), config);
+            }
         }
+
         mutex.unlock();
     }
-	return QLogger::getPointerInstance();
+
+    return QLogger::getPointerInstance();
 }
 
-void QLogger::addLogger(QString logOwner, Configuration* configuration)
+void QLogger::addLogger(QString logOwner, Configuration *configuration)
 {
     QLogger::getInstance();
     mutex.lock();
-    if(!QLogger::getPointerInstance()->loggers.values(logOwner).contains(configuration))
-    {
+
+    if (!QLogger::getPointerInstance()->loggers.values(logOwner).contains(configuration)) {
         configuration->setLogOwner(logOwner);
         QLogger::getPointerInstance()->loggers.insert(logOwner, configuration);
+
+        if (configuration->getOutputType() == Configuration::SIGNAL) {
+            connect(configuration, &Configuration::logMessage,
+                    QLogger::getPointerInstance(), &QLogger::logMessage);
+        }
     }
+
     mutex.unlock();
 }
 
-void QLogger::addLogger(Configuration* configuration)
+void QLogger::addLogger(Configuration *configuration)
 {
     QString logOwner = configuration != NULL ? configuration->getLogOwner() : QString();
     addLogger(logOwner, configuration);
@@ -123,24 +129,25 @@ void QLogger::addLogger(QString logOwner, Configuration::Level lvl,
                         Configuration::OutputType ouputType,
                         QString timestampFormat)
 {
-    Configuration* cfg = new Configuration(logOwner, lvl, ouputType, timestampFormat);
+    Configuration *cfg = new Configuration(logOwner, lvl, ouputType, timestampFormat);
     QLogger::addLogger(logOwner, cfg);
 }
 
 void QLogger::log(Configuration::Level lvl, QString message, QString functionName, int lineNumber, QString owner)
 {
     writex.lock();
-    QList<Configuration*> configs = QLogger::getInstance()->loggers.values(owner);
+    QList<Configuration *> configs = QLogger::getInstance()->loggers.values(owner);
     const int size = configs.size();
-    for(int i = 0 ; i < size ; i++)
-    {
-       Configuration* cfg = configs.at(i);
-       if(lvl <= cfg->getLogLevel())
-       {
-           cfg->getOutputLog()->write(message, Configuration::levelToString(lvl), owner,
-                                 QDateTime::currentDateTime().toString(cfg->getTimestampFormat()), functionName, lineNumber);
-       }
+
+    for (int i = 0 ; i < size ; i++) {
+        Configuration *cfg = configs.at(i);
+
+        if (lvl <= cfg->getLogLevel()) {
+            cfg->getOutputLog()->write(message, Configuration::levelToString(lvl), owner,
+                                       QDateTime::currentDateTime().toString(cfg->getTimestampFormat()), functionName, lineNumber);
+        }
     }
+
     writex.unlock();
 }
 

--- a/qlogger.h
+++ b/qlogger.h
@@ -1,23 +1,26 @@
 /*
- * QLogger - A tiny Qt logging framework.
- *
- * MIT License
- * Copyright (c) 2013 sandro fadiga
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies
- * or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
- * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    QLogger - A tiny Qt logging framework.
+
+    MIT License
+    Copyright (c) 2013 sandro fadiga
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 */
 
 #ifndef QLOGGER_H
@@ -26,18 +29,18 @@
 #include <QAtomicPointer>
 #include <QHash>
 #include <QMutex>
+#include <QObject>
 
 #include "configuration.h"
 
-namespace qlogger
-{
+namespace qlogger {
 
 class Configuration;
 class QLogger;
 
-//! This class is responsible for returning the memory of QLogger singleton and avoid mem leaks
-class QLoggerDestroyer
-{
+//! This class is responsible for returning the memory of QLogger singleton and
+//! avoid mem leaks
+class QLoggerDestroyer {
 public:
     QLoggerDestroyer(QAtomicPointer<QLogger> s = 0);
     ~QLoggerDestroyer();
@@ -47,38 +50,39 @@ private:
     QAtomicPointer<QLogger> singleton;
 
 public:
-	//! Handles the acess to QAtomicPointer methods based on Qt version
-	inline QLogger* getPointerInstance()
-	{
-		#if (QT_VERSION < QT_VERSION_CHECK(5,0,0))
-			return singleton;
-		#else	
-            return singleton.loadAcquire();
-		#endif
-	}
-
+    //! Handles the acess to QAtomicPointer methods based on Qt version
+    inline QLogger *getPointerInstance() {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+        return singleton;
+#else
+        return singleton.loadAcquire();
+#endif
+    }
 };
 
-//! Main QLogger class, its a singleton responsible for register the log messages to
-//! its respective owners and also load the runtime configurations wich defines how each
-//! log message will be displayed.
-class QLogger
-{
-
+//! Main QLogger class, its a singleton responsible for register the log
+//! messages to its respective owners and also load the runtime configurations
+//! wich defines how each log message will be displayed.
+class QLogger : public QObject {
+    Q_OBJECT
 public:
-    //! retrives the global instance of the QLogger class, this is private so no ones need to call this directly
-    static QLogger* getInstance();
+    //! retrives the global instance of the QLogger class, this is private so no
+    //! ones need to call this directly
+    static QLogger *getInstance();
+
+signals:
+    void logMessage(QString);
 
 protected:
     // allow the definition of the destroyer inside the singleton
     friend class QLoggerDestroyer;
-    
-	//! protected constructor to avoid instatiation outside the class
+
+    //! protected constructor to avoid instatiation outside the class
     QLogger();
     virtual ~QLogger();
-	
-	//!
-	void close();
+
+    //!
+    void close();
 
 private:
     //! Singleton instance
@@ -90,38 +94,37 @@ private:
     //! log writing mutex
     static QMutex writex;
 
-    //! this static instance is responsible for call the singleton destructor when program ends
+    //! this static instance is responsible for call the singleton destructor when
+    //! program ends
     static QLoggerDestroyer destroyer;
 
-	//! this methods adds a loger based on a configuration 
-	static void addLogger(QString logOwner, Configuration* configuration);
+    //! this methods adds a loger based on a configuration
+    static void addLogger(QString logOwner, Configuration *configuration);
 
 private:
-	//! Stop the compiler generating methods of copy the object
-    QLogger(QLogger const& copy);            // Not Implemented
-    QLogger& operator=(QLogger const& copy); // Not Implemented
+    //! Stop the compiler generating methods of copy the object
+    QLogger(QLogger const &copy);             // Not Implemented
+    QLogger &operator=(QLogger const &copy);  // Not Implemented
 
-	//! Handles the acess to QAtomicPointer methods based on Qt version
-	static inline QLogger* getPointerInstance()
-	{
-		#if (QT_VERSION < QT_VERSION_CHECK(5,0,0))
-			return instance;
-		#else	
-            return instance.loadAcquire();
-		#endif
-	}
-
+    //! Handles the acess to QAtomicPointer methods based on Qt version
+    static inline QLogger *getPointerInstance() {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+        return instance;
+#else
+        return instance.loadAcquire();
+#endif
+    }
 
 private:
     //! logger added at runtime along with their configurations
-    QMultiHash<QString, Configuration*> loggers;
+    QMultiHash<QString, Configuration *> loggers;
 
 public:
-
-    //! adds a logger with a default configuration to the list of loggers in runtime
+    //! adds a logger with a default configuration to the list of loggers in
+    //! runtime
     static void addLogger(QString logOwner);
 
-    static void addLogger(Configuration* configuration);
+    static void addLogger(Configuration *configuration);
 
     //! adds a logger passing a configuration to the list of loggers in runtime
     static void addLogger(QString logOwner, Configuration::Level lvl,
@@ -129,57 +132,79 @@ public:
                           QString timestampFormat = TIMESTAMP_QLOGGER_FORMAT);
 
     //! log a message to a specific level
-    static void log(Configuration::Level, QString message, QString functionName = QString(), int lineNumber = -1, QString owner = "root");
+    static void log(Configuration::Level, QString message,
+                    QString functionName = QString(), int lineNumber = -1,
+                    QString owner = "root");
 
     //! logs directly to fatal level
-    inline static void fatal(QString message, QString owner = "root", QString functionName = QString(), int lineNumber = -1)
-    {
-        QLogger::log(Configuration::q0FATAL, message, functionName, lineNumber, owner);
+    inline static void fatal(QString message, QString owner = "root",
+                             QString functionName = QString(),
+                             int lineNumber = -1) {
+        QLogger::log(Configuration::q0FATAL, message, functionName, lineNumber,
+                     owner);
     }
 
     //! logs directly to error level
-    inline static void error(QString message, QString owner = "root", QString functionName = QString(), int lineNumber = -1)
-    {
-        QLogger::log(Configuration::q1ERROR, message, functionName, lineNumber, owner);
+    inline static void error(QString message, QString owner = "root",
+                             QString functionName = QString(),
+                             int lineNumber = -1) {
+        QLogger::log(Configuration::q1ERROR, message, functionName, lineNumber,
+                     owner);
     }
 
     //! logs directly to warn level
-    inline static void warn(QString message, QString owner = "root", QString functionName = QString(), int lineNumber = -1)
-    {
-        QLogger::log(Configuration::q2WARN, message, functionName, lineNumber, owner);
+    inline static void warn(QString message, QString owner = "root",
+                            QString functionName = QString(),
+                            int lineNumber = -1) {
+        QLogger::log(Configuration::q2WARN, message, functionName, lineNumber,
+                     owner);
     }
 
     //! logs directly to info level
-    inline static void info(QString message, QString owner = "root", QString functionName = QString(), int lineNumber = -1)
-    {
-        QLogger::log(Configuration::q3INFO, message, functionName, lineNumber, owner);
+    inline static void info(QString message, QString owner = "root",
+                            QString functionName = QString(),
+                            int lineNumber = -1) {
+        QLogger::log(Configuration::q3INFO, message, functionName, lineNumber,
+                     owner);
     }
 
     //! logs directly to debug level
-    inline static void debug(QString message, QString owner = "root", QString functionName = QString(), int lineNumber = -1)
-    {
-        QLogger::log(Configuration::q4DEBUG, message, functionName, lineNumber, owner);
+    inline static void debug(QString message, QString owner = "root",
+                             QString functionName = QString(),
+                             int lineNumber = -1) {
+        QLogger::log(Configuration::q4DEBUG, message, functionName, lineNumber,
+                     owner);
     }
 
     //! logs directly to trace level
-    inline static void trace(QString message, QString owner = "root", QString functionName = QString(), int lineNumber = -1)
-    {
-        QLogger::log(Configuration::q5TRACE, message, functionName, lineNumber, owner);
+    inline static void trace(QString message, QString owner = "root",
+                             QString functionName = QString(),
+                             int lineNumber = -1) {
+        QLogger::log(Configuration::q5TRACE, message, functionName, lineNumber,
+                     owner);
     }
-
 };
 
 // MACROS FOR THE PEOPLE!
-#define QLOG_FATAL(message, ...) QLogger::log(Configuration::q0FATAL, message, __FUNCTION__ , __LINE__, ##__VA_ARGS__);
-#define QLOG_ERROR(message, ...) QLogger::log(Configuration::q1ERROR, message, __FUNCTION__ , __LINE__ , ##__VA_ARGS__);
-#define QLOG_WARN(message, ...) QLogger::log(Configuration::q2WARN, message, __FUNCTION__ , __LINE__ , ##__VA_ARGS__);
-#define QLOG_INFO(message, ...) QLogger::log(Configuration::q3INFO, message, __FUNCTION__ , __LINE__ , ##__VA_ARGS__);
-#define QLOG_DEBUG(message, ...) QLogger::log(Configuration::q4DEBUG, message, __FUNCTION__ , __LINE__ , ##__VA_ARGS__);
-#define QLOG_TRACE(message, ...) QLogger::log(Configuration::q5TRACE, message, __FUNCTION__ , __LINE__ , ##__VA_ARGS__);
+#define QLOG_FATAL(message, ...)                                        \
+    QLogger::log(Configuration::q0FATAL, message, __FUNCTION__, __LINE__, \
+                 ##__VA_ARGS__);
+#define QLOG_ERROR(message, ...)                                        \
+    QLogger::log(Configuration::q1ERROR, message, __FUNCTION__, __LINE__, \
+                 ##__VA_ARGS__);
+#define QLOG_WARN(message, ...)                                        \
+    QLogger::log(Configuration::q2WARN, message, __FUNCTION__, __LINE__, \
+                 ##__VA_ARGS__);
+#define QLOG_INFO(message, ...)                                        \
+    QLogger::log(Configuration::q3INFO, message, __FUNCTION__, __LINE__, \
+                 ##__VA_ARGS__);
+#define QLOG_DEBUG(message, ...)                                        \
+    QLogger::log(Configuration::q4DEBUG, message, __FUNCTION__, __LINE__, \
+                 ##__VA_ARGS__);
+#define QLOG_TRACE(message, ...)                                        \
+    QLogger::log(Configuration::q5TRACE, message, __FUNCTION__, __LINE__, \
+                 ##__VA_ARGS__);
 
-}
+}  // namespace qlogger
 
-
-
-#endif // QLOGGER_H
-
+#endif  // QLOGGER_H

--- a/qlogger.h
+++ b/qlogger.h
@@ -136,6 +136,9 @@ public:
                     QString functionName = QString(), int lineNumber = -1,
                     QString owner = "root");
 
+    //! change the level of a particular owner/output type.
+    static void changelogLevel(QString, Configuration::Level, Configuration::OutputType);
+
     //! logs directly to fatal level
     inline static void fatal(QString message, QString owner = "root",
                              QString functionName = QString(),

--- a/qlogger.pro
+++ b/qlogger.pro
@@ -4,12 +4,11 @@
 #
 #-------------------------------------------------
 
-QT       += core
-QT       -= gui
+QT       += core gui
 
-TEMPLATE = lib
-CONFIG   -= app_bundle
-CONFIG += shared_and_static -debug-and-release build_all
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+TEMPLATE = app
 
 DEFINES += QLOGGER_LIBRARY
 
@@ -47,7 +46,9 @@ SOURCES += \
     qlogger.cpp \
     configuration.cpp \
     textoutput.cpp \
-    xmloutput.cpp
+    xmloutput.cpp \
+    main.cpp \
+    mainwindow.cpp
 
 HEADERS += \
     configfilehandler.h \
@@ -55,7 +56,8 @@ HEADERS += \
     output.h \
     qlogger.h \
     textoutput.h \
-    xmloutput.h
+    xmloutput.h \
+    mainwindow.h
 
 unix {
     target.path = /usr/lib
@@ -65,3 +67,6 @@ unix {
 DISTFILES += \
     qlogger.cfg \
     README
+
+FORMS += \
+    mainwindow.ui

--- a/qlogger.pro
+++ b/qlogger.pro
@@ -9,7 +9,7 @@ QT       -= gui
 
 TEMPLATE = lib
 CONFIG   -= app_bundle
-CONFIG += shared_and_static build_all
+CONFIG += shared_and_static -debug-and-release build_all
 
 DEFINES += QLOGGER_LIBRARY
 

--- a/qlogger.pro
+++ b/qlogger.pro
@@ -9,6 +9,7 @@ QT       -= gui
 
 TEMPLATE = lib
 CONFIG   -= app_bundle
+CONFIG += shared_and_static build_all
 
 DEFINES += QLOGGER_LIBRARY
 

--- a/qlogger.pro
+++ b/qlogger.pro
@@ -1,0 +1,66 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2018-08-25T09:36:16
+#
+#-------------------------------------------------
+
+QT       += core
+QT       -= gui
+
+TEMPLATE = lib
+CONFIG   -= app_bundle
+
+DEFINES += QLOGGER_LIBRARY
+
+# The following define makes your compiler emit warnings if you use
+# any feature of Qt which has been marked as deprecated (the exact warnings
+# depend on your compiler). Please consult the documentation of the
+# deprecated API in order to know how to port your code away from it.
+DEFINES += QT_DEPRECATED_WARNINGS
+
+# You can also make your code fail to compile if you use deprecated APIs.
+# In order to do so, uncomment the following line.
+# You can also select to disable deprecated APIs only up to a certain version of Qt.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+CONFIG(debug, debug|release) {
+    TARGET = qloggerd
+    DESTDIR = ../../build/qlogger
+    OBJECTS_DIR = $$DESTDIR/.objd
+    MOC_DIR = $$DESTDIR/.mocd
+    RCC_DIR = $$DESTDIR/.qrcd
+    UI_DIR = $$DESTDIR/.uid
+}
+
+CONFIG(release, debug|release) {
+    TARGET = qlogger
+    DESTDIR = ../../build/qlogger
+    OBJECTS_DIR = $$DESTDIR/.obj
+    MOC_DIR = $$DESTDIR/.moc
+    RCC_DIR = $$DESTDIR/.qrc
+    UI_DIR = $$DESTDIR/.ui
+}
+
+
+SOURCES += \
+    qlogger.cpp \
+    configuration.cpp \
+    textoutput.cpp \
+    xmloutput.cpp
+
+HEADERS += \
+    configfilehandler.h \
+    configuration.h \
+    output.h \
+    qlogger.h \
+    textoutput.h \
+    xmloutput.h
+
+unix {
+    target.path = /usr/lib
+    INSTALLS += target
+}
+
+DISTFILES += \
+    qlogger.cfg \
+    README

--- a/textoutput.cpp
+++ b/textoutput.cpp
@@ -1,77 +1,61 @@
 /*
- * QLogger - A tiny Qt logging framework.
- *
- * MIT License
- * Copyright (c) 2013 sandro fadiga
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies
- * or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
- * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    QLogger - A tiny Qt logging framework.
+
+    MIT License
+    Copyright (c) 2013 sandro fadiga
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
 */
 
 #include "textoutput.h"
 
 #include <QDateTime>
-#include <QFile>
 #include <QDir>
-#include <iostream>
+#include <QFile>
 #include <QTextCodec>
+#include <iostream>
 
-namespace qlogger
-{
+namespace qlogger {
 
-ConsoleOutput::ConsoleOutput(QString mask)
-    : qTextStream(new QTextStream(stdout))
+BaseOutput::BaseOutput(QString mask)
 {
     // check if a valid log mask is informed, only the log owner is not obligatory
-    if(!mask.contains("%t") || !mask.contains("%m") || !mask.contains("%l"))
+    if (!mask.contains("%t") || !mask.contains("%m") || !mask.contains("%l")) {
         this->logTextMask = DEFAULT_TEXT_MASK;
-    else
+
+    } else {
         this->logTextMask = mask;
-
-	qTextStream->device()->setTextModeEnabled(true);
+    }
 }
 
-ConsoleOutput::~ConsoleOutput()
-{
-	if(qTextStream)
-		delete qTextStream;
-}
+BaseOutput::~BaseOutput() {}
 
-QString ConsoleOutput::getLogTextMask() const
+QString BaseOutput::getLogTextMask() const
 {
     return logTextMask;
 }
 
-void ConsoleOutput::write(const QString message,
-                          const QString owner,
-                          const QString lvl,
-                          const QString timestamp,
-                          const QString functionName,
-                          const int lineNumber)
-{
-    //QByteArray msg = QTextCodec::convertFromUnicode(); TODO correct the conversion to from utf-8 to the console output (local)
-    *qTextStream << formatLogText(this->logTextMask, message, owner, lvl, timestamp, functionName, lineNumber) << endl;
-}
-
-QString ConsoleOutput::formatLogText(const QString logFormatMask,
-                                     const QString message,
-                                     const QString owner,
-                                     const QString lvl,
-                                     const QString timestamp,
-                                     const QString functionName,
-                                     const int lineNumber)
+QString BaseOutput::formatLogText(const QString logFormatMask,
+                                  const QString message, const QString owner,
+                                  const QString lvl, const QString timestamp,
+                                  const QString functionName,
+                                  const int lineNumber)
 {
     QString text = QString(logFormatMask);
     text = text.replace("%t", timestamp);
@@ -83,72 +67,106 @@ QString ConsoleOutput::formatLogText(const QString logFormatMask,
     return text;
 }
 
+ConsoleOutput::ConsoleOutput(QString mask)
+    : BaseOutput(mask), qTextStream(new QTextStream(stdout))
+{
+    qTextStream->device()->setTextModeEnabled(true);
+}
+
+ConsoleOutput::~ConsoleOutput()
+{
+    if (qTextStream) {
+        delete qTextStream;
+    }
+}
+
+void ConsoleOutput::write(const QString message, const QString owner,
+                          const QString lvl, const QString timestamp,
+                          const QString functionName, const int lineNumber)
+{
+    // QByteArray msg = QTextCodec::convertFromUnicode(); TODO correct the
+    // conversion to from utf-8 to the console output (local)
+    *qTextStream << formatLogText(this->logTextMask, message, owner, lvl,
+                                  timestamp, functionName, lineNumber)
+                 << endl;
+}
+
 void ConsoleOutput::close()
 {
     qTextStream->flush();
 }
 
-TextFileOutput::TextFileOutput(QString logOwner, QString logFormatMask, QString path,
-                               int fileSizeInKb, QString fileMask,
+TextFileOutput::TextFileOutput(QString logOwner, QString logFormatMask,
+                               QString path, int fileSizeInKb, QString fileMask,
                                QString timestampFormat)
-    : ConsoleOutput(logFormatMask),
-      logOwner(logOwner), filePath(path), fileMaxSizeInBytes(fileSizeInKb * 1024),
-      fileNameMask(fileMask), fileNameTimestampFormat(timestampFormat), currentFile(NULL)
+    : ConsoleOutput(logFormatMask), logOwner(logOwner), filePath(path),
+      fileMaxSizeInBytes(fileSizeInKb * 1024), fileNameMask(fileMask),
+      fileNameTimestampFormat(timestampFormat), currentFile(NULL)
 {
     qTextStream = NULL;
 
     // check if a valid size was informed, minimum of 10k
-    if(fileMaxSizeInBytes < 10240)
-       fileMaxSizeInBytes = 10240;
+    if (fileMaxSizeInBytes < 10240) {
+        fileMaxSizeInBytes = 10240;
+    }
 
     // check if a valid path was informed
     QDir test(filePath);
-    if(filePath.isEmpty() || !test.exists())
-		filePath = QDir::currentPath();
-    else
+
+    if (filePath.isEmpty() || !test.exists()) {
+        filePath = QDir::currentPath();
+
+    } else {
         filePath = path;
+    }
 
-    if(fileNameTimestampFormat.isEmpty())
+    if (fileNameTimestampFormat.isEmpty()) {
         fileNameTimestampFormat = FILE_NAME_TIMESTAMP_FORMAT;
+    }
 
-    if(fileNameMask.isEmpty() || !(fileNameMask.contains("%1") && fileNameMask.contains("%2") && fileNameMask.contains("%3")))
+    if (fileNameMask.isEmpty() ||
+        !(fileNameMask.contains("%1") && fileNameMask.contains("%2") &&
+          fileNameMask.contains("%3"))) {
         fileNameMask = TEXT_FILE_NAME_MASK;
-    else
+
+    } else {
         fileNameMask = fileMask;
+    }
 
     createNextFile();
 }
 
 TextFileOutput::~TextFileOutput()
 {
-	if(qTextStream)
-		delete qTextStream;
-	if(currentFile)
-		delete currentFile;
+    if (qTextStream) {
+        delete qTextStream;
+    }
+
+    if (currentFile) {
+        delete currentFile;
+    }
 }
 
 void TextFileOutput::createNextFile()
 {
-	if(qTextStream && currentFile)
-    {
+    if (qTextStream && currentFile) {
         qTextStream->flush();
         delete qTextStream;
         currentFile->flush();
         currentFile->close();
     }
-    // TEXT FILE MODE
-	QDir dir(filePath);
-	QString myFile = dir.absoluteFilePath(getFileName());
-	currentFile = new QFile(myFile);
 
-    if(currentFile->open(QIODevice::WriteOnly | QIODevice::Text))
-	{
-		qTextStream = new QTextStream(currentFile);
-	}	
-    else // Fall back to console mode
-	{
+    // TEXT FILE MODE
+    QDir dir(filePath);
+    QString myFile = dir.absoluteFilePath(getFileName());
+    currentFile = new QFile(myFile);
+
+    if (currentFile->open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qTextStream = new QTextStream(currentFile);
+
+    } else { // Fall back to console mode
         qTextStream = new QTextStream(stdout);
-	}
+    }
 
     // enables the output to text mode and have correct line breaks
     qTextStream->device()->setTextModeEnabled(true);
@@ -157,32 +175,43 @@ void TextFileOutput::createNextFile()
 
 QString TextFileOutput::getFileName() const
 {
-    QString name = fileNameMask
-            .arg(QCoreApplication::applicationName())
-            .arg(logOwner)
-            .arg(QDateTime::currentDateTime().toString(fileNameTimestampFormat));
+    QString name =
+        fileNameMask.arg(QCoreApplication::applicationName())
+        .arg(logOwner)
+        .arg(QDateTime::currentDateTime().toString(fileNameTimestampFormat));
     return name;
 }
 
-void TextFileOutput::write(const QString message,
-                           const QString owner,
-                           const QString lvl,
-                           const QString timestamp,
-                           const QString functionName,
-                           const int lineNumber)
+void TextFileOutput::write(const QString message, const QString owner,
+                           const QString lvl, const QString timestamp,
+                           const QString functionName, const int lineNumber)
 {
-    if(currentFile && currentFile->size() > fileMaxSizeInBytes)
-    {
+    if (currentFile && currentFile->size() > fileMaxSizeInBytes) {
         createNextFile();
     }
-    ConsoleOutput::write(message, lvl, owner, timestamp, functionName, lineNumber);
+
+    ConsoleOutput::write(message, lvl, owner, timestamp, functionName,
+                         lineNumber);
 }
 
-//!
 void TextFileOutput::close()
 {
     qTextStream->flush();
-	currentFile->close();
+    currentFile->close();
 }
 
+SignalOutput::SignalOutput(QString logFormatMask) : BaseOutput(logFormatMask) {}
+
+SignalOutput::~SignalOutput() {}
+
+void SignalOutput::write(const QString message, const QString owner,
+                         const QString lvl, const QString timestamp,
+                         const QString functionName, const int lineNumber)
+{
+    emit logMessage(formatLogText(this->logTextMask, message, owner, lvl,
+                                  timestamp, functionName, lineNumber));
 }
+
+void SignalOutput::close() {}
+
+} // namespace qlogger

--- a/textoutput.h
+++ b/textoutput.h
@@ -1,23 +1,26 @@
 /*
- * QLogger - A tiny Qt logging framework.
- *
- * MIT License
- * Copyright (c) 2013 sandro fadiga
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
- * and associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies
- * or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
- * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    QLogger - A tiny Qt logging framework.
+
+    MIT License
+    Copyright (c) 2013 sandro fadiga
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 */
 
 #ifndef TEXTOUTPUT_H
@@ -26,8 +29,9 @@
 #include "output.h"
 
 #include <QCoreApplication>
-#include <QTextStream>
 #include <QFile>
+#include <QObject>
+#include <QTextStream>
 
 #include <QPointer>
 
@@ -37,82 +41,85 @@
 // %m - message
 static const QString DEFAULT_TEXT_MASK = "%t [%o] <%l> (%f) {line:%n} - %m";
 
-//! log_appname_logname_datetime.txt %1 = application name , %2 = owner , %3 = timestamp
+//! log_appname_logname_datetime.txt %1 = application name , %2 = owner , %3 =
+//! timestamp
 static const QString TEXT_FILE_NAME_MASK = "log_%1_%2_%3.txt";
 
 //! will be used on the file name mask
 static const QString FILE_NAME_TIMESTAMP_FORMAT = "yyyyMMdd_hhmmss";
 
-namespace qlogger
-{
+namespace qlogger {
 
-class ConsoleOutput : public Output
-{
+class BaseOutput : public Output {
 public:
-    //! This default constructor sets the class to be on console mode, all logs will be redirected to stdout
-    ConsoleOutput(QString mask = DEFAULT_TEXT_MASK);
-    //ConsoleOutput();
-    virtual ~ConsoleOutput();
-
-    //! this method is responsible for write the log text in the selected output
-    virtual void write(const QString message,
-                       const QString owner,
-                       const QString lvl,
-                       const QString timestamp,
-                       const QString functionName,
-                       const int lineNumber);
-    //! implement from output
-    virtual void close();
+    BaseOutput(QString mask = DEFAULT_TEXT_MASK);
+    virtual ~BaseOutput();
 
     //! return the current mask used to format the log text
     QString getLogTextMask() const;
 
 protected:
-    //! the qt class to output texts
-    QTextStream* qTextStream;
-
     //! the text mask used to format the log output
     QString logTextMask;
 
-    //! uses the mask param and log message to generate the text string which will be logged out.
-    QString formatLogText(const QString logFormatMask,
-                          const QString message,
-                          const QString owner,
-                          const QString lvl,
-                          const QString timestamp,
-                          const QString functionName,
+    //! uses the mask param and log message to generate the text string which will
+    //! be logged out.
+    QString formatLogText(const QString logFormatMask, const QString message,
+                          const QString owner, const QString lvl,
+                          const QString timestamp, const QString functionName,
                           const int lineNumber);
 };
 
-//! this class is responsible for write plain text log messages for file or stdout (console)
-class TextFileOutput : public ConsoleOutput
-{
+class ConsoleOutput : public BaseOutput {
+public:
+    //! This default constructor sets the class to be on console mode, all logs
+    //! will be redirected to stdout
+    ConsoleOutput(QString mask);
+    // ConsoleOutput();
+    virtual ~ConsoleOutput();
+
+    //! this method is responsible for write the log text in the selected output
+    virtual void write(const QString message, const QString owner,
+                       const QString lvl, const QString timestamp,
+                       const QString functionName, const int lineNumber);
+    //! implement from output
+    virtual void close();
+
+protected:
+    //! the qt class to output texts
+    QTextStream *qTextStream;
+};
+
+//! this class is responsible for write plain text log messages for file or
+//! stdout (console)
+class TextFileOutput : public ConsoleOutput {
 
 public:
-    //! This constructor sets the class to operate in text file mode, all logs will be written in a file
-    TextFileOutput(QString logOwner, QString logFormatMask, QString filePath , int fileMaxSizeInKb , QString fileNameMask = TEXT_FILE_NAME_MASK,
+    //! This constructor sets the class to operate in text file mode, all logs
+    //! will be written in a file
+    TextFileOutput(QString logOwner, QString logFormatMask, QString filePath,
+                   int fileMaxSizeInKb,
+                   QString fileNameMask = TEXT_FILE_NAME_MASK,
                    QString fileNameTimestampFormat = FILE_NAME_TIMESTAMP_FORMAT);
     virtual ~TextFileOutput();
 
     //! this method is responsible for write the log text in the selected output
-    virtual void write(const QString message,
-                       const QString owner,
-                       const QString lvl,
-                       const QString timestamp,
-                       const QString functionName,
-                       const int lineNumber);
+    virtual void write(const QString message, const QString owner,
+                       const QString lvl, const QString timestamp,
+                       const QString functionName, const int lineNumber);
 
     virtual void close();
 
 protected:
-    //! this method is used to generate a file name based on the application name, log owner and date time
+    //! this method is used to generate a file name based on the application name,
+    //! log owner and date time
     QString getFileName() const;
 
-    //! this method is called when a new file needs to be created due to size limitation
+    //! this method is called when a new file needs to be created due to size
+    //! limitation
     virtual void createNextFile();
 
 protected:
-
     //! this is the log owner name of this output text, used to form the file name
     QString logOwner;
 
@@ -128,11 +135,28 @@ protected:
     //! the timestamp format to be used in the file name
     QString fileNameTimestampFormat;
 
-    //! this attribute represents the current file being used, when in file mode, otherwise = NULL
-    QFile* currentFile;
-
+    //! this attribute represents the current file being used, when in file mode,
+    //! otherwise = NULL
+    QFile *currentFile;
 };
 
-}
+class SignalOutput : public QObject, public BaseOutput {
+    Q_OBJECT
+public:
+    SignalOutput(QString logFormatMask);
+    ~SignalOutput();
+
+    //! this method is responsible for write the log text in the selected output
+    virtual void write(const QString message, const QString owner,
+                       const QString lvl, const QString timestamp,
+                       const QString functionName, const int lineNumber);
+
+    virtual void close();
+
+signals:
+    void logMessage(QString);
+};
+
+} // namespace qlogger
 
 #endif // TEXTOUTPUT_H


### PR DESCRIPTION
Hi, I've been using your logger for a while but needed to output via a Qt signal/slot connection. To do this I had to modify the original project, adding a SignalOutput class. this made it necessary to make SignalOutput, Configuration and QLogger extend QObject i order to access the Signal capability, then routethe signal automatically from SignalOutput via Configuration to QLogger::logMessage(QString) as there is no direct access to the SignalOutput class. I also Split a separate BaseOutput class to allow me to use formatLogText() without the QTextStream in ConsoleObject which is not needed for SignalOutput.

Configuration and ConfigFileHandler have been modified to allow the output type to be set in qlogger.cfg. However I noticed while testing that the setup as stands before I modified it, doesn't actually use the qlogger.cfg file as recursiveFolderSearch() only searches for directories, no files were actually searched so I changed the filter from QDir::Dirs|Dir::NoDotAndDotDot to QDir::Dirs|QDir::Files|QDir::NoDotAndDotDot.

The README file has been amended to show the changes.

All a user has to do is select an OutputType of SIGNAL and make a connection to his recipient class.
